### PR TITLE
Orgin/user/flipper92017/2021 05 18/atcc front fix

### DIFF
--- a/teensy_code/ATCC/sensors.hpp
+++ b/teensy_code/ATCC/sensors.hpp
@@ -14,42 +14,42 @@ ADCChip adc2(ADC2_CS);
 ADCChip adc3(ADC3_CS);
 
 // front sensors
-ADCSensor sus_travel_fl_sens(3, 0, 1000); // will need corrected values
-ADCSensor sus_travel_fr_sens(0, 0, 1000); // (sensor is not chosen yet  ??? nice.)
+ADCSensor sus_travel_fl_sens(0, 0, 1000); // will need corrected values
+ADCSensor sus_travel_fr_sens(2, 0, 1000); // (sensor is not chosen yet  ??? nice.)
 
-ADCSensor brake_temp_fr_sens(4, 500, 5);
-ADCSensor brake_temp_fl_sens(7, 500, 5);
+ADCSensor brake_temp_fr_sens(10, 500, 5);
+ADCSensor brake_temp_fl_sens(4, 500, 5);
 
 ADCSensor brake_pressure_front_sens(1, 500, 2);
-ADCSensor brake_pressure_rear_sens(2, 500, 2);
+ADCSensor brake_pressure_rear_sens(3, 500, 2);
 
-ADCSensor swa_sens(4, 0, 0); // can't do yet
+ADCSensor swa_sens(7, 0, 0); // can't do yet
 
 ADCSensor tire_temp_fr_inner_sens(5, 400, 30);
 ADCSensor tire_temp_fr_middle_sens(6, 400, 30);
 ADCSensor tire_temp_fr_outer_sens(0, 400, 30);
-ADCSensor tire_temp_fl_inner_sens(3, 400, 30);
-ADCSensor tire_temp_fl_middle_sens(5, 400, 30);
+ADCSensor tire_temp_fl_inner_sens(0, 400, 30);
+ADCSensor tire_temp_fl_middle_sens(4, 400, 30);
 ADCSensor tire_temp_fl_outer_sens(6, 400, 30);
 
-ADCSensor coolant_temp_mid_sens(5, 0, 1000); // leave as is. returns voltage in V
+ADCSensor coolant_temp_mid_sens(4, 0, 1000); // leave as is. returns voltage in V
 
 // rear sensors
-ADCSensor sus_travel_rr_sens(0, 0, 1000);
-ADCSensor sus_travel_rl_sens(3, 0, 1000);
+ADCSensor sus_travel_rr_sens(2, 0, 1000);
+ADCSensor sus_travel_rl_sens(0, 0, 1000);
 
-ADCSensor coolant_temp_outlet_sens(5, 0, 1000);
+ADCSensor coolant_temp_outlet_sens(4, 0, 1000);
 ADCSensor coolant_temp_inlet_sens(6, 0, 1000);
 
-ADCSensor tire_temp_rl_inner_sens(3, 400, 30);
-ADCSensor tire_temp_rl_middle_sens(5, 400, 30);
+ADCSensor tire_temp_rl_inner_sens(0, 400, 30);
+ADCSensor tire_temp_rl_middle_sens(4, 400, 30);
 ADCSensor tire_temp_rl_outer_sens(6, 400, 30);
 ADCSensor tire_temp_rr_inner_sens(5, 400, 30);
 ADCSensor tire_temp_rr_middle_sens(6, 400, 30);
-ADCSensor tire_temp_rr_outer_sens(0, 400, 30);
+ADCSensor tire_temp_rr_outer_sens(2, 400, 30);
 
-ADCSensor brake_temp_rr_sens(4, 500, 5);
-ADCSensor brake_temp_rl_sens(7, 500, 5);
+ADCSensor brake_temp_rr_sens(7, 500, 5);
+ADCSensor brake_temp_rl_sens(4, 500, 5);
 
 
 void initialize_ADCs()

--- a/teensy_code/TCGPS/TCGPS.ino
+++ b/teensy_code/TCGPS/TCGPS.ino
@@ -5,6 +5,7 @@
 #include <EasyTimer.h>
 #include <BoardTemp.h>
 #include <EepromHelper.h>
+#include <Printers.h>
 #include <XBee.h>
 
 // can bus decleration


### PR DESCRIPTION
Fixed issues with ATCC code (channels for each ADC were not correct) and added an include statement to make telemetry compile correctly (#include <Printers.h>) 